### PR TITLE
Add apiConstants package with typed API constants

### DIFF
--- a/apiConstants/.gitignore
+++ b/apiConstants/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+lib/
+# dotenv environment variable files
+.env
+.env.*
+package-lock.json
+*.sh

--- a/apiConstants/package.json
+++ b/apiConstants/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@thinkcove-lib/apiconstants",
+  "version": "1.0.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/apiConstants/src/apiConstants/apiConstants.ts
+++ b/apiConstants/src/apiConstants/apiConstants.ts
@@ -1,0 +1,45 @@
+
+/**
+ * Object map for API methods, fully typed.
+ */
+export type HapiRouteMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
+ 
+export const API_METHODS: Record<HapiRouteMethod, HapiRouteMethod> = {
+  GET: "GET",
+  POST: "POST",
+  PUT: "PUT",
+  DELETE: "DELETE",
+  PATCH: "PATCH",
+  OPTIONS: "OPTIONS"
+};
+
+/**
+ * Literal type for available auth strategy keys.
+ */
+export type AuthStrategy = string;
+
+/**
+ * Object map for auth strategies.
+ */
+export const STRATEGY: Record<AuthStrategy, AuthStrategy> = {
+  SIMPLE: "simple"
+};
+
+/**
+ * Base API identifier string.
+ */
+export const API: string = "api";
+
+
+
+/**
+ *  All constants above are **named exports**.
+ *  To use in your project:
+ *
+ * import {
+ *   API,
+ *   API_METHODS,
+ *   STRATEGY,
+ *   type AuthStrategy
+ * } from '@your-scope/api-utils';
+ */

--- a/apiConstants/src/index.ts
+++ b/apiConstants/src/index.ts
@@ -1,0 +1,1 @@
+export { API_METHODS } from "./apiConstants/apiConstants";

--- a/apiConstants/tsconfig.json
+++ b/apiConstants/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
Introduces the apiConstants package containing typed API method and auth strategy constants, a base API identifier, and TypeScript configuration. Includes initial .gitignore, package.json, and index export for API_METHODS.