### PR TITLE
Add 'files' field to package.json

### DIFF
--- a/hapi-ts/base/package.json
+++ b/hapi-ts/base/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "tsc",
     "lint": "eslint \"src/**/*.{js,ts}\"",


### PR DESCRIPTION
Included the 'lib' directory in the 'files' field to specify which files should be published with the package.