### PR TITLE
Communication - base method defined for send sms -pay2sms

### DIFF
--- a/communication/pay2sms/.gitignore
+++ b/communication/pay2sms/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+lib/
+# dotenv environment variable files
+.env
+.env.*
+package-lock.json
+*.sh
+# Logs
+*.log

--- a/communication/pay2sms/.npmignore
+++ b/communication/pay2sms/.npmignore
@@ -1,0 +1,9 @@
+src/
+tsconfig.json
+.eslintrc
+.prettierrc
+*.log
+*.md
+*.test.*
+*.spec.*
+*.mjs

--- a/communication/pay2sms/.prettierignore
+++ b/communication/pay2sms/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+package-lock.json
+lib

--- a/communication/pay2sms/.prettierrc
+++ b/communication/pay2sms/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/communication/pay2sms/README.md
+++ b/communication/pay2sms/README.md
@@ -1,0 +1,193 @@
+
+# 📲 @thinkcove/communication
+
+A TypeScript utility to send SMS messages using [Pay2SMS](https://www.pay2sms.in/). Built for backend services, this library supports templated messages, custom Axios options, and integrates seamlessly with your server applications using Axios and Mustache.
+
+---
+
+## 🚀 Features
+
+- ✅ Simple and reliable SMS sending via Pay2SMS  
+- 📄 Supports templated messages using Mustache (`{{variable}}`)  
+- 🔧 Customizable via Axios options (headers, timeouts, etc.)  
+- 🔐 Designed for secure backend usage  
+- 🧪 Typed interfaces for safer development  
+
+---
+
+## 📦 Installation
+
+```bash
+npm install @thinkcove/communication
+```
+
+---
+
+## 🛠️ Usage
+
+### 1. Import the function
+
+```ts
+import { sendPay2sms } from "@thinkcove/communication";
+```
+
+### 2. Configure your Pay2SMS credentials
+
+```ts
+const smsConfig = {
+  smsUrl: "https://www.pay2sms.in/sendsms", // Pay2SMS API endpoint
+  senderId: "ABCDEF",                       // Registered sender ID
+  creditType: "1",                          // "1" = Transactional, "2" = Promotional
+  communicationToken: "YOUR_API_TOKEN",    // Token from Pay2SMS
+  templateId: "DLT_TEMPLATE_ID"            // Approved DLT template ID
+};
+```
+
+### 3. Prepare your SMS input
+
+```ts
+const input = {
+  phoneNumber: "1010101010",
+  template: "Hi {{name}}, your OTP is {{otp}}.",
+  templateData: {
+    name: "John",
+    otp: "123456"
+  }
+};
+```
+
+### 4. (Optional) Add Axios configuration
+
+```ts
+// Optional: Customize Axios request
+const axiosOptions = {
+  timeout: 7000, // custom timeout (ms)
+  method: "GET", // override method (default is GET)
+  headers: {
+    "X-App-Source": "billing-system",
+    "Accept": "application/json"
+  }
+};
+
+```
+
+### 5. Send the SMS
+
+```ts
+const result = await sendPay2sms(input, smsConfig, axiosOptions);
+
+if (result.success) {
+  console.log("✅ SMS sent successfully:", result.response?.data);
+} else {
+  console.error("❌ SMS sending failed:", result.error);
+}
+```
+
+---
+
+## 🧩 Template Engine
+
+This package uses [`mustache`](https://www.npmjs.com/package/mustache) to render message templates.
+
+**Example:**
+
+```ts
+template: "Hi {{name}}, your OTP is {{otp}}.",
+templateData: {
+  name: "Alice",
+  otp: "789456"
+}
+```
+
+**Output:**
+
+```
+Hi Alice, your OTP is 789456.
+```
+
+---
+
+## 📄 API Reference
+
+### `sendPay2sms(input, smsConfig, axiosOptions?)`
+
+Send an SMS using Pay2SMS with a templated message.
+
+#### ➤ Parameters
+
+- `input`: `SmsSendInput`  
+- `smsConfig`: `SmsConfigProps`  
+- `axiosOptions` *(optional)*: Additional Axios configuration (method, headers, etc.)
+
+#### ➤ Returns
+
+- A `Promise<SmsResponse>` containing success status, message, and response/error.
+
+---
+
+## 🧾 Types
+
+### `SmsSendInput`
+
+```ts
+type SmsSendInput = {
+  phoneNumber: string;
+  template: string;
+  templateData: Record<string, string | number | boolean>;
+};
+```
+
+### `SmsConfigProps`
+
+```ts
+type SmsConfigProps = {
+  smsUrl: string;
+  senderId: string;
+  creditType: string;
+  communicationToken: string;
+  templateId: string;
+};
+```
+
+### `SmsResponse`
+
+```ts
+type SmsResponse = {
+  success: boolean;
+  message: string;
+  response?: AxiosResponse;
+  error?: any;
+};
+```
+
+---
+
+## 🔐 Security Best Practices
+
+- Do **not** expose your `communicationToken` on the frontend.  
+- Store credentials securely using environment variables:
+
+```env
+PAY2SMS_TOKEN=your_api_token
+SENDER_ID=your_sender_id
+TEMPLATE_ID=your_dlt_template_id
+```
+
+- Load environment variables using [`dotenv`](https://www.npmjs.com/package/dotenv):
+
+```ts
+import dotenv from "dotenv";
+dotenv.config();
+```
+
+---
+
+## 📎 Useful Links
+
+- 🔗 [Pay2SMS](https://www.pay2sms.in/)
+
+---
+
+## 📝 License
+
+ISC License

--- a/communication/pay2sms/README.md
+++ b/communication/pay2sms/README.md
@@ -1,7 +1,7 @@
 
 # 📲 @thinkcove/communication
 
-A TypeScript utility to send SMS messages using [Pay2SMS](https://www.pay2sms.in/). Built for backend services, this library supports templated messages, custom Axios options, and integrates seamlessly with your server applications using Axios and Mustache.
+A TypeScript utility to send SMS messages using [Pay2SMS](https://pay4sms.in/). Built for backend services, this library supports templated messages, custom Axios options, and integrates seamlessly with your server applications using Axios and Mustache.
 
 ---
 
@@ -35,7 +35,7 @@ import { sendPay2sms } from "@thinkcove/communication";
 
 ```ts
 const smsConfig = {
-  smsUrl: "https://www.pay2sms.in/sendsms", // Pay2SMS API endpoint
+  smsUrl: "https://pay4sms.in/sendsms/", // Pay2SMS API endpoint
   senderId: "ABCDEF",                       // Registered sender ID
   creditType: "1",                          // "1" = Transactional, "2" = Promotional
   communicationToken: "YOUR_API_TOKEN",    // Token from Pay2SMS

--- a/communication/pay2sms/eslint.config.mjs
+++ b/communication/pay2sms/eslint.config.mjs
@@ -1,0 +1,15 @@
+import globals from "globals";
+import pluginJs from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default [
+  { files: ["*/.{js,mjs,cjs,ts}"] },
+  { languageOptions: { globals: globals.browser } },
+  pluginJs.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off"
+    }
+  }
+];

--- a/communication/pay2sms/package.json
+++ b/communication/pay2sms/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@thinkcove/communication",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint \"src/**/*.{js,ts}\"",
+    "lint:fix": "eslint --fix \"src/**/*.{js,ts}\"",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "axios": "^1.11.0",
+    "mustache": "^4.2.0"
+  },
+  "devDependencies": {
+    "@types/mustache": "^4.2.6",
+    "@types/node": "^24.0.14",
+    "eslint": "^9.31.0",
+    "prettier": "^3.6.2",
+    "typescript-eslint": "^8.37.0"
+  }
+}

--- a/communication/pay2sms/package.json
+++ b/communication/pay2sms/package.json
@@ -11,7 +11,8 @@
     "build": "tsc",
     "lint": "eslint \"src/**/*.{js,ts}\"",
     "lint:fix": "eslint --fix \"src/**/*.{js,ts}\"",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check 'src/**/*.{js,jsx,mjs,cjs,ts,tsx,json}'"
   },
   "keywords": [],
   "author": "",

--- a/communication/pay2sms/src/axios/axios.ts
+++ b/communication/pay2sms/src/axios/axios.ts
@@ -1,0 +1,33 @@
+import axios, { AxiosRequestConfig, AxiosResponse, Method } from "axios";
+import { SmsResponse } from "../types/smsTypes";
+import { AXIOS_MESSAGE } from "../constants/constant";
+
+type ConfigWithMethod = Omit<AxiosRequestConfig, "method"> & {
+  method?: Method;
+};
+
+/**
+ * Executes an HTTP request with full Axios options. Defaults to GET.
+ */
+export const axiosCall = async (config: ConfigWithMethod = {}): Promise<SmsResponse> => {
+  const method = config.method ?? "GET"; // method is now type-safe
+
+  try {
+    const response: AxiosResponse = await axios.request({
+      ...config,
+      method
+    });
+
+    return {
+      success: true,
+      message: AXIOS_MESSAGE.SUCCESS,
+      response
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      message: AXIOS_MESSAGE.FAILURE,
+      error
+    };
+  }
+};

--- a/communication/pay2sms/src/constants/constant.ts
+++ b/communication/pay2sms/src/constants/constant.ts
@@ -1,0 +1,4 @@
+export const AXIOS_MESSAGE = {
+  SUCCESS: "SMS sent successfully",
+  FAILURE: "SMS Axios call failed"
+};

--- a/communication/pay2sms/src/generateMessage/templateGenerate.ts
+++ b/communication/pay2sms/src/generateMessage/templateGenerate.ts
@@ -1,0 +1,21 @@
+import { renderTemplate } from "../mustache/mustacheHelper";
+import { MustacheTemplateProps } from "../types/smsTypes";
+
+/**
+ * Renders a Mustache template with the provided data.
+ *
+ * @param data - An object containing key-value pairs to inject into the template.
+ * @param props - An object containing the Mustache template string.
+ * @returns A rendered string with the injected data.
+ *
+ * @example
+ * const template = 'Hello, {{name}}!';
+ * const message = generateMessage({ name: 'Alice' }, { template });
+ * // message => 'Hello, Alice!'
+ */
+export const generateMessage = (
+  props: MustacheTemplateProps,
+  data: Record<string, any>
+): string => {
+  return renderTemplate(props.template, data);
+};

--- a/communication/pay2sms/src/index.ts
+++ b/communication/pay2sms/src/index.ts
@@ -1,0 +1,4 @@
+export { sendPay2sms } from "./sms/sentSms";
+export { renderTemplate } from "./mustache/mustacheHelper";
+export * from "./types/smsTypes";
+export { generateMessage } from "./generateMessage/templateGenerate";

--- a/communication/pay2sms/src/mustache/mustacheHelper.ts
+++ b/communication/pay2sms/src/mustache/mustacheHelper.ts
@@ -1,0 +1,11 @@
+import mustache from "mustache";
+
+/**
+ * Generic mustache template renderer
+ * @param template - The mustache template string
+ * @param templateData - The data to inject into the template
+ * @returns Rendered string
+ */
+export const renderTemplate = (template: string, templateData: any): string => {
+  return mustache.render(template, templateData);
+};

--- a/communication/pay2sms/src/sms/sentSms.ts
+++ b/communication/pay2sms/src/sms/sentSms.ts
@@ -1,0 +1,48 @@
+import { generateMessage } from "../generateMessage/templateGenerate";
+import { SmsConfigProps, SmsResponse, SmsSendInput } from "../types/smsTypes";
+import { axiosCall } from "../axios/axios";
+import { AxiosRequestConfig, Method } from "axios";
+
+/**
+ * Constructs the SMS gateway URL with query parameters.
+ */
+export const buildSmsUrl = (
+  phoneNumber: string,
+  message: string,
+  config: SmsConfigProps
+): string => {
+  const params = new URLSearchParams({
+    token: config.communicationToken,
+    credit: config.creditType,
+    sender: config.senderId,
+    number: phoneNumber,
+    templateid: config.templateId,
+    message
+  });
+
+  return `${config.smsUrl}?${params.toString()}`;
+};
+
+/**
+ * Sends an SMS message using the provided template and templateData.
+ *
+ * @param input - Contains recipient's phoneNumber, template, templateData.
+ * @param smsConfig - SMS gateway configuration.
+ * @param axiosOptions - Optional Axios options (method, headers, timeout, etc.).
+ */
+export const sendPay2sms = async (
+  input: SmsSendInput,
+  smsConfig: SmsConfigProps,
+  axiosOptions: Omit<AxiosRequestConfig, "url"> & { method?: Method } = {}
+): Promise<SmsResponse> => {
+  const content = generateMessage({ template: input.template }, input.templateData);
+  const smsUrl = buildSmsUrl(input.phoneNumber, content, smsConfig);
+
+  const result = await axiosCall({
+    url: smsUrl,
+    method: axiosOptions.method ?? "GET", // default to GET if not provided
+    ...axiosOptions
+  });
+
+  return result;
+};

--- a/communication/pay2sms/src/types/smsTypes.ts
+++ b/communication/pay2sms/src/types/smsTypes.ts
@@ -1,0 +1,33 @@
+import { AxiosResponse } from "axios";
+
+export type SmsConfigProps = {
+  smsUrl: string;
+  senderId: string;
+  creditType: string;
+  communicationToken: string;
+  templateId: string;
+};
+
+export type TemplateValue =
+  | string
+  | number
+  | boolean
+  | TemplateValue[]
+  | { [key: string]: TemplateValue };
+
+export type SmsSendInput = {
+  phoneNumber: string;
+  template: string;
+  templateData: { [key: string]: TemplateValue };
+};
+
+export type SmsResponse = {
+  success: boolean;
+  message: string;
+  response?: AxiosResponse;
+  error?: any;
+};
+
+export type MustacheTemplateProps = {
+  template: any;
+};

--- a/communication/pay2sms/tsconfig.json
+++ b/communication/pay2sms/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmitOnError": true,
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
- Re-exported Axios types (AxiosRequestConfig, AxiosResponse, Method) from package entry point
- Exposed internal axiosCall utility for advanced usage
- Ensured Sms-related types (SmsSendInput, SmsConfigProps, SmsResponse) are publicly available
- Improves DX by enabling consumers to access types and helpers directly from @thinkcove/communication